### PR TITLE
fix: only keep unique frames in `FrameCoverage` object

### DIFF
--- a/src/gamecov/__init__.py
+++ b/src/gamecov/__init__.py
@@ -1,7 +1,7 @@
-from .loader import load_mp4, load_mp4_lazy, get_frame_cov
+from .loader import load_mp4, load_mp4_lazy
 from .dedup import hash_dedup
 from .frame import Frame
-from .frame_cov import FrameCoverage, FrameMonitor
+from .frame_cov import FrameCoverage, FrameMonitor, get_frame_cov
 from .stitch import stitch_images
 from .cov_base import CoverageItem, Coverage, CoverageMonitor
 

--- a/src/gamecov/frame_cov.py
+++ b/src/gamecov/frame_cov.py
@@ -1,23 +1,31 @@
 import hashlib
 
+from returns.result import safe
+
 from .frame import Frame
 from .dedup import hash_dedup
 from .cov_base import Coverage, CoverageMonitor
+from .loader import load_mp4
 
 
 class FrameCoverage(Coverage[Frame]):
     """track frame coverage in a game-play session"""
 
-    def __init__(self, frames: list[Frame]):
-        self.frames = frames
+    def __init__(self, recording_path: str):
+        self.recording_path = recording_path
+        frames = load_mp4(recording_path)
+        self.unique_frames = hash_dedup(frames)
 
     @property
     def trace(self) -> list[Frame]:
-        return self.frames
+        """Note: this function is lazy, loading the frames AGAIN from the recording path.
+        You should not call this function if you already have the frames loaded.
+        """
+        return load_mp4(self.recording_path)
 
     @property
     def coverage(self) -> set[Frame]:
-        return set(hash_dedup(self.trace))
+        return set(self.unique_frames)
 
     @property
     def path_id(self) -> str:
@@ -37,3 +45,10 @@ class FrameMonitor(CoverageMonitor[Frame]):
         """Add a new execution coverage record to the monitor."""
         self.path_seen.add(cov.path_id)
         self.item_seen = hash_dedup(self.item_seen.union(cov.coverage))
+
+
+@safe
+def get_frame_cov(url: str) -> FrameCoverage:
+    """Get the frame coverage for a given MP4 file."""
+    frames = load_mp4(url)
+    return FrameCoverage(frames)

--- a/src/gamecov/loader.py
+++ b/src/gamecov/loader.py
@@ -1,10 +1,8 @@
 from typing import Generator
 
 import imageio.v3 as iio
-from returns.result import safe
 
 from .frame import Frame
-from .frame_cov import FrameCoverage
 
 
 def load_mp4(url: str) -> list[Frame]:
@@ -22,10 +20,3 @@ def load_mp4_lazy(url: str) -> Generator[Frame, None, None]:
     # iterate over large videos
     for frame in iio.imiter(url, plugin="pyav", extension=".mp4"):
         yield Frame.fromarray(frame)
-
-
-@safe
-def get_frame_cov(url: str) -> FrameCoverage:
-    """Get the frame coverage for a given MP4 file."""
-    frames = load_mp4(url)
-    return FrameCoverage(frames)


### PR DESCRIPTION
This PR fixes #9 and thereby should fix https://github.com/SecurityLab-UCD/game-fuzz/issues/67.